### PR TITLE
Fix syntax in example page that is incompatible with IE11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1268,6 +1268,7 @@ rewindButton.addEventListener('click', () => embla.scrollTo(0), false)
     <a href="https://github.com/gunnarx2"><img src="https://avatars2.githubusercontent.com/u/10469652?s=122&v=4" title="gunnarx2" width="66" height="66" style="max-width:100%;"></a>
     <a href="https://github.com/xiel"><img src="https://avatars0.githubusercontent.com/u/615522?s=122&v=4" title="xiel" width="66" height="66" style="max-width:100%;"></a>
     <a href="https://github.com/niubsta"><img src="https://avatars0.githubusercontent.com/u/270320?s=122&v=4" title="niubsta" width="66" height="66" style="max-width:100%;"></a>
+    <a href="https://github.com/allen-garvey"><img src="https://avatars1.githubusercontent.com/u/9314727?s=400&v=4" title="allen-garvey" width="66" height="66" style="max-width:100%;"></a>
   </p>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -439,7 +439,7 @@
             function() {
               embla.scrollTo(i)
             },
-            false,
+            false
           )
         })
       }
@@ -485,7 +485,7 @@
         var disablePrevAndNextBtns = togglePrevAndNextBtns(
           prevBtn,
           nextBtn,
-          embla,
+          embla
         )
         addDotBtnClickListeners(dotsArray, embla)
         addPrevNextBtnClickListeners(prevBtn, nextBtn, embla)


### PR DESCRIPTION
Removes ES2017 syntax for trailing commas in function calls from the example page, as this breaks on IE11.