### PR TITLE
Fix errors when embedding on Pastel (usepastel.com)

### DIFF
--- a/src/vanilla/components/animation.ts
+++ b/src/vanilla/components/animation.ts
@@ -7,8 +7,6 @@ export type Animation = {
 }
 
 export function Animation(callback: FrameRequestCallback): Animation {
-  const run = requestAnimationFrame.bind(window)
-  const end = cancelAnimationFrame.bind(window)
   let animationFrame = 0
 
   function ifAnimating(active: boolean, cb: Callback): Callback {
@@ -18,11 +16,11 @@ export function Animation(callback: FrameRequestCallback): Animation {
   }
 
   function start(): void {
-    animationFrame = run(callback)
+    animationFrame = window.requestAnimationFrame(callback)
   }
 
   function stop(): void {
-    end(animationFrame)
+    window.cancelAnimationFrame(animationFrame)
     animationFrame = 0
   }
 


### PR DESCRIPTION
This is to fix errors that occur on sites that override the `window` global with a Proxy'd version of their own. I am not sure exactly _why_ this is causing errors, but on its face its not surprising that `someFunction.bind(window)` when `window` is actually a custom `Proxy` might not work correctly.

Specifically, this happens on sites embedded on https://usepastel.com

For a test of this, navigate to

-  https://usepastel.com/link/2w7yy/

Navigate to the **works.html** and **fails.html** pages to view the errors. The **works.html** page uses a build from the same changes made in this PR.

If the above pastel link is down, run through the following to recreate:

-  Clone the repo at https://github.com/romellem/temp-site (specifically, the files at [embla-carousel/](https://github.com/romellem/temp-site/tree/master/embla-carousel).
-  Create a GitHub Pages site for this newly clone repo / set of files.
-  Create a new account at Pastel - https://usepastel.com/signup - and add the newly spun up GitHub Page as a "Pastel Canvas."
-  Navigate to the two pages in questions, and view the errors that follow.