### PR TITLE
Auto resize option

### DIFF
--- a/src/vanilla/components/options.ts
+++ b/src/vanilla/components/options.ts
@@ -5,6 +5,7 @@ import { ScrollContainOptionType } from './scrollContain'
 
 export type OptionsType = {
   align: AlignmentOptionType
+  autoResize: boolean
   axis: AxisOptionType
   containScroll: ScrollContainOptionType
   direction: DirectionOptionType
@@ -22,6 +23,7 @@ export type OptionsType = {
 
 export const defaultOptions: OptionsType = {
   align: 'center',
+  autoResize: true,
   axis: 'x',
   containScroll: '',
   direction: 'ltr',

--- a/src/vanilla/index.ts
+++ b/src/vanilla/index.ts
@@ -66,8 +66,10 @@ function EmblaCarousel(
     engine = Engine(sliderRoot, container, slides, options, events)
     eventStore.add(window, 'resize', debouncedResize)
     engine.translate.to(engine.location)
-    rootNodeSize = engine.axis.measureSize(sliderRoot.getBoundingClientRect())
 
+    if (options.autoResize) {
+      rootNodeSize = engine.axis.measureSize(sliderRoot.getBoundingClientRect())
+    }
     if (options.loop) {
       if (!engine.slideLooper.canLoop()) {
         deActivate()
@@ -148,10 +150,10 @@ function EmblaCarousel(
 
   function resize(): void {
     if (!activated) return
-    const newRootNodeSize = engine.axis.measureSize(
-      sliderRoot.getBoundingClientRect(),
-    )
-    if (rootNodeSize !== newRootNodeSize) reActivate()
+    if (options.autoResize) {
+      const size = engine.axis.measureSize(sliderRoot.getBoundingClientRect())
+      if (rootNodeSize !== size) reActivate()
+    }
     events.emit('resize')
   }
 


### PR DESCRIPTION
# Auto resize option
This PR adds a new option called `{ autoSpacing: boolean }` which let's users decide if Embla Carousel should call `embla.reInit()` automatically when the window is resized. This was always the case before adding this functionality. Even if a user opts out of this, Embla will still fire the `resize` event for users to conveniently hook onto it.

## Usage
For example, you might want to opt out of the automatically called `reInit` if you want to change options when the current breakpoint changes:
```js
const BREAKPOINT = 1024
const shouldBeDraggable = () => window.innerWidth < BREAKPOINT

const options = {
  autoResize: false,
  draggable: shouldBeDraggable()
}
const embla = EmblaCarousel(emblaNode, options)

embla.on('resize', () => {
  // Before this PR, Embla would already have called embla.reInit() once by the time it fires the resize event,
  // so the reInit below would be unnecessary extra work.
  embla.reInit({ draggable: shouldBeDraggable() })
})
```