### PR TITLE
Allow to assign slide nodes as slots within a web component using shadow DOM

### DIFF
--- a/packages/embla-carousel/package.json
+++ b/packages/embla-carousel/package.json
@@ -69,5 +69,8 @@
     "shx": "^0.3.3",
     "ts-jest": "^26.5.5",
     "typescript": "^4.2.4"
+  },
+  "dependencies": {
+    "@webcomponents/webcomponentsjs": "^2.6.0"
   }
 }

--- a/packages/embla-carousel/src/__tests__/embla-carousel-vanilla/index.test.ts
+++ b/packages/embla-carousel/src/__tests__/embla-carousel-vanilla/index.test.ts
@@ -3,6 +3,11 @@ import EmblaCarousel, {
   EmblaCarouselType,
 } from '../../embla-carousel-vanilla/index'
 
+// required when transpiling to es5 and web-components are used
+// otherwise the following error is thrown:
+// Class constructor HTMLElement cannot be invoked without 'new'
+import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js'
+
 const initializeEmbla = (
   withContainer: boolean = true,
   withSlides: boolean = true,
@@ -19,6 +24,23 @@ const initializeEmbla = (
   }
   return () => EmblaCarousel(rootNode, options)
 }
+
+class EmblaCarouselComponent extends HTMLElement {
+  carousel?: EmblaCarouselType
+
+  connectedCallback() {
+    const shadowRoot = this.attachShadow({ mode: 'open' })
+    const rootNode = document.createElement('div')
+    const containerNode = document.createElement('slot')
+    containerNode.setAttribute('name', 'slide')
+
+    rootNode.appendChild(containerNode)
+    shadowRoot.appendChild(rootNode)
+
+    this.carousel = EmblaCarousel(rootNode)
+  }
+}
+window.customElements.define('embla-carousel-component', EmblaCarouselComponent)
 
 describe('EmblaCarousel', () => {
   describe('When initialized it does not throw when', () => {
@@ -42,6 +64,24 @@ describe('EmblaCarousel', () => {
 
     test('The container node is not provided', () => {
       expect(initializeEmbla(false, false)).toThrow()
+    })
+  })
+
+  describe('When initialized inside web component with slot', () => {
+    test('It uses the assigned slots as slide nodes', () => {
+      const carouselNode = document.createElement(
+        'embla-carousel-component',
+      ) as EmblaCarouselComponent
+      for (let i = 0; i < 3; i += 1) {
+        const slide = document.createElement('div')
+        slide.setAttribute('slot', 'slide')
+        carouselNode.appendChild(slide)
+      }
+      document.body.appendChild(carouselNode)
+      // wait until componenet got attached
+      return Promise.resolve().then(() => {
+        expect(carouselNode.carousel?.slideNodes().length).toBe(3)
+      })
     })
   })
 })

--- a/packages/embla-carousel/src/embla-carousel-vanilla/index.ts
+++ b/packages/embla-carousel/src/embla-carousel-vanilla/index.ts
@@ -51,11 +51,18 @@ function EmblaCarousel(
 
   function setupElements(): void {
     if (!sliderRoot) throw new Error('Missing root node 😢')
-    const sliderContainer = sliderRoot.querySelector('*')
+    const sliderContainer = sliderRoot.querySelector<
+      HTMLElement | HTMLSlotElement
+    >('*')
     if (!sliderContainer) throw new Error('Missing container node 😢')
 
     container = sliderContainer as HTMLElement
-    slides = Array.prototype.slice.call(container.children)
+    if (sliderContainer instanceof HTMLSlotElement) {
+      slides = Array.prototype.slice.call(sliderContainer.assignedElements())
+    } else {
+      slides = Array.prototype.slice.call(container.children)
+    }
+
     optionsPseudo = OptionsPseudo(sliderRoot)
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2368,6 +2368,11 @@
     "@webassemblyjs/ast" "1.11.0"
     "@xtuc/long" "4.2.2"
 
+"@webcomponents/webcomponentsjs@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.6.0.tgz#7d1674c40bddf0c6dd974c44ffd34512fe7274ff"
+  integrity sha512-Moog+Smx3ORTbWwuPqoclr+uvfLnciVd6wdCaVscHPrxbmQ/IJKm3wbB7hpzJtXWjAq2l/6QMlO85aZiOdtv5Q==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
Thanks for this great carousel library.

I would like to build my own `<my-embla-carousel>` components, which then could be used as such:

```html
<my-embla-carousel index="1">
  <my-slide slot="slide">Slide 1</my-slide>
  <my-slide slot="slide">Slide 2</my-slide>
</my-embla-carousel>
```

This pull request slightly adjusts how the slide children are collected when a slot element is involved.


