### PR TITLE
fix typo on line 82 'pliugin' to 'plugin'

### DIFF
--- a/packages/embla-carousel-docs/src/content/pages/plugins/autoplay.md
+++ b/packages/embla-carousel-docs/src/content/pages/plugins/autoplay.md
@@ -79,7 +79,7 @@ If this parameter is enabled, autoplay will be stopped when it reaches last slid
 
 ## Methods
 
-The Autoplay pliugin exposes a set of **useful methods** which lets you control it. Assuming you've stored the plugin instance in a variable, a method is called like demonstrated below:
+The Autoplay plugin exposes a set of **useful methods** which lets you control it. Assuming you've stored the plugin instance in a variable, a method is called like demonstrated below:
 
 ```js
 import Autoplay from 'embla-carousel-autoplay'


### PR DESCRIPTION
This just a simple typo fix in the documentation for the autoplay plugin.