### PR TITLE
Add a hint for flexbox and autoheight compatability

### DIFF
--- a/packages/embla-carousel-docs/src/content/pages/plugins/auto-height.md
+++ b/packages/embla-carousel-docs/src/content/pages/plugins/auto-height.md
@@ -45,6 +45,15 @@ You can make use of CSS transitions to **transition height** changes. But beware
 }
 ```
 
+If you are following along with the Get Started guide, you will probably want to amend your CSS with the following :
+
+```css{3}
+.embla__container {
+  display: flex;
+  align-items: flex-start;
+}
+```
+
 ## Options
 
 The Auto Height plugin accepts an optional **options** object as the first argument. Here's an example of how to make use of it:


### PR DESCRIPTION
When following along with the Get Started guide, the example CSS doesn't
allow autoheight to work properly. The flex container will set all the
slides to be the same height making the autoheight script useless.
Adding some direction to the docs to amend the example CSS will help
avoid this issue.

I couldn't get gatsby to build the site so this PR is blind I am afraid. Seeing
 as the suggestion is a minor one,  I didn't foresee this being a major issue.
Feel free to insist, it will be a bit of a gap before I can update the PR in that case.

Feedback, criticism and amend requests welcome.