### PR TITLE
[Feat]: Support AbortController for event handlers

### DIFF
--- a/packages/embla-carousel/src/__tests__/events.test.ts
+++ b/packages/embla-carousel/src/__tests__/events.test.ts
@@ -68,4 +68,143 @@ describe('➡️  Events', () => {
       expect(callback).toHaveBeenCalledTimes(0)
     })
   })
+
+  describe('Events with AbortController signal:', () => {
+    test('Calls the provided callback when signal is not aborted', () => {
+      const testApi = EmblaCarousel(mockTestElements(FIXTURE_EVENTS))
+      const callback = jest.fn()
+      const abortController = new AbortController()
+
+      testApi.on('select', callback, { signal: abortController.signal })
+      testApi.scrollNext()
+      expect(callback).toHaveBeenCalledTimes(1)
+      testApi.destroy()
+    })
+
+    test('Does NOT call the callback when signal is aborted before event emission', () => {
+      const testApi = EmblaCarousel(mockTestElements(FIXTURE_EVENTS))
+      const callback = jest.fn()
+      const abortController = new AbortController()
+
+      testApi.on('select', callback, { signal: abortController.signal })
+      abortController.abort()
+      testApi.scrollNext()
+      expect(callback).toHaveBeenCalledTimes(0)
+      testApi.destroy()
+    })
+
+    test('Does NOT call the callback when signal is aborted after event listener is added', () => {
+      const testApi = EmblaCarousel(mockTestElements(FIXTURE_EVENTS))
+      const callback = jest.fn()
+      const abortController = new AbortController()
+
+      testApi.on('select', callback, { signal: abortController.signal })
+      testApi.scrollNext()
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      abortController.abort()
+      testApi.scrollNext()
+      expect(callback).toHaveBeenCalledTimes(1)
+      testApi.destroy()
+    })
+
+    test('Multiple callbacks with different signals work independently', () => {
+      const testApi = EmblaCarousel(mockTestElements(FIXTURE_EVENTS))
+      const callback1 = jest.fn()
+      const callback2 = jest.fn()
+      const abortController1 = new AbortController()
+      const abortController2 = new AbortController()
+
+      testApi.on('select', callback1, { signal: abortController1.signal })
+      testApi.on('select', callback2, { signal: abortController2.signal })
+
+      testApi.scrollNext()
+      expect(callback1).toHaveBeenCalledTimes(1)
+      expect(callback2).toHaveBeenCalledTimes(1)
+
+      abortController1.abort()
+      testApi.scrollNext()
+      expect(callback1).toHaveBeenCalledTimes(1)
+      expect(callback2).toHaveBeenCalledTimes(2)
+      testApi.destroy()
+    })
+
+    test('Callback can still be removed with off() even when using signal', () => {
+      const testApi = EmblaCarousel(mockTestElements(FIXTURE_EVENTS))
+      const callback = jest.fn()
+      const abortController = new AbortController()
+
+      testApi.on('select', callback, { signal: abortController.signal })
+      testApi.scrollNext()
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      testApi.off('select', callback)
+      testApi.scrollNext()
+      expect(callback).toHaveBeenCalledTimes(1)
+      testApi.destroy()
+    })
+
+    test('Works with user-triggered emit() when signal is not aborted', () => {
+      const testApi = EmblaCarousel(mockTestElements(FIXTURE_EVENTS))
+      const callback = jest.fn()
+      const abortController = new AbortController()
+
+      testApi.on('select', callback, { signal: abortController.signal })
+      testApi.emit('select')
+      expect(callback).toHaveBeenCalledTimes(1)
+      testApi.destroy()
+    })
+
+    test('Does NOT work with user-triggered emit() when signal is aborted', () => {
+      const testApi = EmblaCarousel(mockTestElements(FIXTURE_EVENTS))
+      const callback = jest.fn()
+      const abortController = new AbortController()
+
+      testApi.on('select', callback, { signal: abortController.signal })
+      abortController.abort()
+      testApi.emit('select')
+      expect(callback).toHaveBeenCalledTimes(0)
+      testApi.destroy()
+    })
+
+    test('Automatically removes listener from memory when signal is aborted', () => {
+      const testApi = EmblaCarousel(mockTestElements(FIXTURE_EVENTS))
+      const callback1 = jest.fn()
+      const callback2 = jest.fn()
+      const abortController = new AbortController()
+
+      testApi.on('select', callback1, { signal: abortController.signal })
+      testApi.on('select', callback2)
+
+      testApi.emit('select')
+      expect(callback1).toHaveBeenCalledTimes(1)
+      expect(callback2).toHaveBeenCalledTimes(1)
+
+      abortController.abort()
+
+      testApi.emit('select')
+      expect(callback1).toHaveBeenCalledTimes(1)
+      expect(callback2).toHaveBeenCalledTimes(2)
+
+      testApi.off('select', callback1)
+      testApi.emit('select')
+      expect(callback1).toHaveBeenCalledTimes(1)
+      expect(callback2).toHaveBeenCalledTimes(3)
+      testApi.destroy()
+    })
+
+    test('Does not interfere with manually removing aborted listener via off()', () => {
+      const testApi = EmblaCarousel(mockTestElements(FIXTURE_EVENTS))
+      const callback = jest.fn()
+      const abortController = new AbortController()
+
+      testApi.on('select', callback, { signal: abortController.signal })
+      abortController.abort()
+
+      testApi.off('select', callback)
+      testApi.emit('select')
+      expect(callback).toHaveBeenCalledTimes(0)
+      testApi.destroy()
+    })
+  })
 })

--- a/packages/embla-carousel/src/components/EventHandler.ts
+++ b/packages/embla-carousel/src/components/EventHandler.ts
@@ -24,7 +24,11 @@ export interface EmblaEventListType {
 export type EventHandlerType = {
   init: (emblaApi: EmblaCarouselType) => void
   emit: (evt: EmblaEventType) => EventHandlerType
-  on: (evt: EmblaEventType, cb: CallbackType) => EventHandlerType
+  on: (
+    evt: EmblaEventType,
+    cb: CallbackType,
+    options?: { signal?: AbortSignal }
+  ) => EventHandlerType
   off: (evt: EmblaEventType, cb: CallbackType) => EventHandlerType
   clear: () => void
 }
@@ -46,13 +50,22 @@ export function EventHandler(): EventHandlerType {
     return self
   }
 
-  function on(evt: EmblaEventType, cb: CallbackType): EventHandlerType {
+  function on(
+    evt: EmblaEventType,
+    cb: CallbackType,
+    options?: { signal?: AbortSignal }
+  ): EventHandlerType {
     listeners[evt] = getListeners(evt).concat([cb])
+
+    options?.signal?.addEventListener('abort', () => {
+      off(evt, cb)
+    })
+
     return self
   }
 
   function off(evt: EmblaEventType, cb: CallbackType): EventHandlerType {
-    listeners[evt] = getListeners(evt).filter((e) => e !== cb)
+    listeners[evt] = getListeners(evt).filter((callback) => callback !== cb)
     return self
   }
 


### PR DESCRIPTION
`AbortController` provides two big conveniences:

1. You can have one `AbortController` instance to clean up all of your handlers for a given context. Rather than a cleanup function that needs to be aware of everything it needs to clean up, just call `ac.abort()`.
2. You can define your handlers inline without needing to keep a reference to them in order to clean them up.
