### PR TITLE
[Docs]: Add version selector to VersionBadge

### DIFF
--- a/website/src/components/VersionBadge/VersionBadge.tsx
+++ b/website/src/components/VersionBadge/VersionBadge.tsx
@@ -1,38 +1,114 @@
 'use client'
 
+import { ChangeEvent } from 'react'
 import styled from 'styled-components'
 import { CARD_STYLES } from '@/utils/card'
 import { SPACINGS } from '@/utils/spacings'
 import { BORDER_RADIUSES } from '@/utils/border'
 import { FONT_SIZES, FONT_WEIGHTS } from '@/utils/font-sizes'
 import { COLORS } from '@/utils/theme'
-import { usePathname } from 'next/navigation'
-import { getVersionFromPathname } from '@/utils/slug'
+import { usePathname, useRouter } from 'next/navigation'
+import {
+  getVersionFromPathname,
+  joinSlugs,
+  prefixSlugWithDocs
+} from '@/utils/slug'
+import { DOCS_LATEST_VERSION, DOCS_VERSIONS } from '@/utils/global-data'
+import { setRoutesLoading } from '../Routes/routes-reducer'
+import { useAppDispatch } from '@/hooks/redux'
 
 const VersionBadgeWrapper = styled.div`
   ${CARD_STYLES};
   display: inline-flex;
-  padding: 0.2rem ${SPACINGS.THREE};
+  align-items: center;
+  padding: ${SPACINGS.ONE} ${SPACINGS.THREE};
   border-radius: ${BORDER_RADIUSES.SOFT};
   font-size: ${FONT_SIZES.COMPLEMENTARY};
   color: ${COLORS.TEXT_LOW_CONTRAST};
 `
 
-const VersionBadgeKey = styled.span`
+const VersionBadgeKey = styled.label`
   font-weight: ${FONT_WEIGHTS.SEMI_BOLD};
-  margin-right: 0.4rem;
+  margin-right: ${SPACINGS.ONE};
+`
+
+const VersionSelect = styled.select`
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  width: 100%;
+  cursor: pointer;
+  font-weight: ${FONT_WEIGHTS.SEMI_BOLD};
+  outline: none;
+
+  &::-ms-expand {
+    display: none;
+  }
 `
 
 type PropType = {}
 
+const DOCS_WITH_VERSION_REGEX = /^\/docs(?:\/v\d+)?/
+
+function getDocsSubPath(pathname = ''): string[] {
+  if (!pathname.startsWith('/docs')) return []
+  return pathname
+    .replace(DOCS_WITH_VERSION_REGEX, '')
+    .split('/')
+    .filter(Boolean)
+}
+
+function getVersionPathname(pathname = '', major: number): string {
+  const versionPrefix = major === DOCS_LATEST_VERSION.MAJOR ? '' : `v${major}`
+  const versionAndSubpath = joinSlugs(
+    versionPrefix,
+    ...getDocsSubPath(pathname)
+  )
+  return prefixSlugWithDocs(versionAndSubpath)
+}
+
 export function VersionBadge(props: PropType) {
   const { ...restProps } = props
+  const router = useRouter()
   const pathname = usePathname()
   const version = getVersionFromPathname(pathname)
+  const dispatch = useAppDispatch()
+
+  function onVersionChange(event: ChangeEvent<HTMLSelectElement>) {
+    const major = Number(event.target.value)
+    const nextPathname = getVersionPathname(pathname, major)
+
+    if (nextPathname === pathname) return
+    dispatch(setRoutesLoading(true))
+    router.push(nextPathname)
+  }
 
   return (
     <VersionBadgeWrapper {...restProps}>
-      <VersionBadgeKey>Version:</VersionBadgeKey> {version.NAME}
+      <VersionBadgeKey htmlFor="version">Version:</VersionBadgeKey>
+
+      <VersionSelect
+        aria-label="Select documentation version"
+        value={String(version.MAJOR)}
+        name="version"
+        id="version"
+        onChange={onVersionChange}
+      >
+        {DOCS_VERSIONS.map((docsVersion) => {
+          const versionLabel = `v${docsVersion.MAJOR}`
+          const versionSuffix = docsVersion.SUFFIX
+            ? ` (${docsVersion.SUFFIX})`
+            : ''
+
+          return (
+            <option key={versionLabel} value={docsVersion.MAJOR}>
+              {versionLabel}
+              {versionSuffix}
+            </option>
+          )
+        })}
+      </VersionSelect>
     </VersionBadgeWrapper>
   )
 }

--- a/website/src/utils/global-data.ts
+++ b/website/src/utils/global-data.ts
@@ -25,12 +25,14 @@ export type VersionType = {
   NAME: string
   MAJOR: number
   SLUG: string
+  SUFFIX?: string
 }
 
 export const DOCS_LATEST_VERSION: VersionType = {
   NAME: packageJson.version,
   MAJOR: Number(packageJson.version.split('.')[0]),
-  SLUG: prefixSlugWithDocs('')
+  SLUG: prefixSlugWithDocs(''),
+  SUFFIX: 'latest'
 }
 
 export const DOCS_VERSIONS: VersionType[] = [
@@ -38,7 +40,8 @@ export const DOCS_VERSIONS: VersionType[] = [
   {
     NAME: '8.6.0',
     MAJOR: 8,
-    SLUG: prefixSlugWithDocs('v8')
+    SLUG: prefixSlugWithDocs('v8'),
+    SUFFIX: 'stable'
   }
 ]
 


### PR DESCRIPTION
Adds dropdown functionality to the `VersionBadge`, allowing the user to select between versions.

Uses `DOCS_LATEST_VERSION, DOCS_VERSIONS` from `@/utils/global-data`

I added a `SUFFIX` key to the `VersionType` for "latest" and "stable". This is optional and could be removed if it's gonna F with anything else on the site I'm unaware of, but it does give us an easy way of giving the user more context around the releases (v8 = "stable").

This is my first PR, so let me know if you'd like me to change anything here. Otherwise, it's pretty straightforward and follows a common pattern.