### PR TITLE
[Docs]: Document how to honor `prefers-reduced-motion` settings

### DIFF
--- a/website/src/content/v8/pages/api/options.mdx
+++ b/website/src/content/v8/pages/api/options.mdx
@@ -307,6 +307,8 @@ Choose scroll axis between `x` and `y`. Remember to stack your slides horizontal
 
 An object with options that will be applied for a given breakpoint by overriding the options at the root level.
 
+To honor [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion) user settings, a breakpoint media query entry can be added to disable animations: `'(prefers-reduced-motion: reduce)': { duration: 0 }`.
+
 <Admonition type="note">
   **Note:** If multiple queries match, they will be merged. And when breakpoint
   options clash, the last one in the list has precedence.

--- a/website/src/content/v9/pages/api/options.mdx
+++ b/website/src/content/v9/pages/api/options.mdx
@@ -312,6 +312,8 @@ Choose scroll axis between `x` and `y`. Remember to stack your slides horizontal
 
 An object with options that will be applied for a given breakpoint by overriding the options at the root level.
 
+To honor [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion) user settings, a breakpoint media query entry can be added to disable animations: `'(prefers-reduced-motion: reduce)': { duration: 0 }`.
+
 <Admonition type="note">
   **Note:** If multiple queries match, they will be merged. And when breakpoint
   options clash, the last one in the list has precedence.

--- a/website/src/content/v9/pages/plugins/accessibility.mdx
+++ b/website/src/content/v9/pages/plugins/accessibility.mdx
@@ -45,6 +45,23 @@ Start by installing the **npm package** and save it to your dependencies:
   </TabsItem>
 </Tabs>
 
+<Admonition type="note">
+  **Note:** To honor [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion) user settings, it is recommended to add a media query in the `breakpoints` option of the carousel constructor. 
+  Learn more about the [`breakpoints`](/docs/api/options#breakpoints) option.
+
+<br />
+
+<PrismHighlight
+  language="ts"
+  hideLabel
+  code={`{
+    breakpoints: {
+      '(prefers-reduced-motion: reduce)': { duration: 0 }
+    }
+}`}
+/>
+</Admonition>
+
 ## Options
 
 Below follows an exhaustive **list of all** `Accessibility` **options** and their default values.


### PR DESCRIPTION
Add a note about how to honor user reduced motion preferences to the v8, v9, and Accessibility plugin documentation.

- Related to discussion: https://github.com/davidjerleke/embla-carousel/discussions/1147